### PR TITLE
Pin dependency: eslint@9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - 👷🏻 Test framework moved from Jest to Node.js test runner, by [@compulim](https://github.com/compulim) in PR [#54](https://github.com/compulim/message-port-rpc/pull/54)
+- 👷🏻 Pinned to `eslint@9` as required by `eslint-plugin-react@7.37.5`, by [@compulim](https://github.com/compulim) in PR [#59](https://github.com/compulim/message-port-rpc/pull/59)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,12 @@
     "init": "npm run init:dev --if-present && npm run init:prod --if-present",
     "init:dev": "npm install --save-dev @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint-plugin-react eslint-plugin-react-hooks prettier"
   },
+  "pinDependencies": {
+    "eslint": [
+      "9",
+      "eslint-plugin-react@7.37.5 does not support eslint@10 yet"
+    ]
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- 👷🏻 Pinned to `eslint@9` as required by `eslint-plugin-react@7.37.5`, by [@compulim](https://github.com/compulim) in PR [#59](https://github.com/compulim/message-port-rpc/pull/59)

## Specific changes

> Please list each individual specific change in this pull request.

- `eslint-plugin-react@7.37.5` does not support eslint@10 yet