### PR TITLE
Auto-populate transferable objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Transferable objects in call arguments and return values are automatically added to `TransferList`, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/message-port-rpc/pull/XXX)
+- Transferable objects in call arguments and return values are automatically added to `TransferList`, by [@compulim](https://github.com/compulim) in PR [#65](https://github.com/compulim/message-port-rpc/pull/65)
 
 ### Removed
 
-- 💥 `transfer` in call `Options` is removed in favor of the auto-transfer feature, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/message-port-rpc/pull/XXX)
+- 💥 `transfer` in call `Options` is removed in favor of the auto-transfer feature, by [@compulim](https://github.com/compulim) in PR [#65](https://github.com/compulim/message-port-rpc/pull/65)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - 💥 `transfer` in call `Options` is removed in favor of the auto-transfer feature, by [@compulim](https://github.com/compulim) in PR [#65](https://github.com/compulim/message-port-rpc/pull/65)
-
-### Removed
-
 ## [2.0.1] - 2026-05-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | Icon | Description                                                    |
 | ---- | -------------------------------------------------------------- |
 | 👷🏻   | Related to development experience and non-production impacting |
+| 💥   | Related to API breaking changes                                |
 
 ## [Unreleased]
+
+### Added
+
+- Transferable objects in call arguments and return values are automatically added to `TransferList`, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/message-port-rpc/pull/XXX)
+
+### Removed
+
+- 💥 `transfer` in call `Options` is removed in favor of the auto-transfer feature, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/message-port-rpc/pull/XXX)
+
+### Removed
 
 ## [2.0.1] - 2026-05-31
 

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ With a new pair of `MessagePort`, messages are queued until the event listener c
 
 ### What can be passed as arguments and return value?
 
-All arguments and return value will be send over the `MessagePort`. The values must be [transferable object](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) using the [Structured Clone Algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) by the underlying `MessagePort`.
+All arguments and return value will be send over the `MessagePort`. The `MessagePort` implementation should send the value using the [Structured Clone Algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). You should not pass `function` or `class` as an argument or return value.
 
-In other words, you cannot pass `function` or `class` as an argument or return value.
+[Transferable objects](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) in call arguments and return values are automatically populated into the `transfer` argument of `MessagePort.postMessage` function call.
 
 ### Will it pass the `this` context?
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ With a new pair of `MessagePort`, messages are queued until the event listener c
 
 ### What can be passed as arguments and return value?
 
-All arguments and return value will be send over the `MessagePort`. The `MessagePort` implementation should send the value using the [Structured Clone Algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). You should not pass `function` or `class` as an argument or return value.
+All arguments and return value will be sent over the `MessagePort`. The `MessagePort` implementation should send the value using the [Structured Clone Algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). You should not pass `function` or `class` as an argument or return value.
 
 [Transferable objects](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) in call arguments and return values are automatically populated into the `transfer` argument of `MessagePort.postMessage` function call.
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ function messagePortRPC<T extends (...args: unknown[]) => Promise<unknown>>(
 ): {
   (...args: Parameters<T>): Promise<ReturnType<T>>;
 
-  withOptions: (init: { signal?: AbortSignal; transfer?: Transferable[] }) => (...args: Parameters<T>): Promise<ReturnType<T>>;
+  withOptions: (init: { signal?: AbortSignal }) => (...args: Parameters<T>): Promise<ReturnType<T>>;
 };
 
 function forGenerator<
@@ -168,7 +168,7 @@ function forGenerator<
 ): {
   (...args: Parameters<T>): AsyncGenerator<TYield, TReturn, TNext>;
 
-  withOptions: (init: { signal?: AbortSignal; transfer?: Transferable[] }) => (...args: Parameters<T>): AsyncGenerator<TYield, TReturn, TNext>;
+  withOptions: (init: { signal?: AbortSignal }) => (...args: Parameters<T>): AsyncGenerator<TYield, TReturn, TNext>;
 };
 ```
 
@@ -184,7 +184,7 @@ With a new pair of `MessagePort`, messages are queued until the event listener c
 
 ### What can be passed as arguments and return value?
 
-All arguments and return value will be send over the `MessagePort`. The values must be transferable using the [Structured Clone Algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) by the underlying `MessagePort`.
+All arguments and return value will be send over the `MessagePort`. The values must be [transferable object](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) using the [Structured Clone Algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) by the underlying `MessagePort`.
 
 In other words, you cannot pass `function` or `class` as an argument or return value.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1298,9 +1299,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1315,9 +1313,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1332,9 +1327,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1349,9 +1341,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1366,9 +1355,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1383,9 +1369,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1400,9 +1383,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1417,9 +1397,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1434,9 +1411,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1451,9 +1425,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1468,9 +1439,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1485,9 +1453,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1502,9 +1467,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1707,6 +1669,7 @@
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1793,6 +1756,7 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -2036,6 +2000,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2338,6 +2303,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2934,6 +2900,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2997,6 +2964,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5174,6 +5142,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5272,6 +5241,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6547,6 +6517,7 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/message-port-rpc/src/getAllTransfer.ts
+++ b/packages/message-port-rpc/src/getAllTransfer.ts
@@ -1,14 +1,16 @@
 import { workthru } from 'workthru';
 import isTransferable from './isTransferable.ts';
 
-export default function getAllTransfer(data: unknown): MessagePort[] {
-  const transferSet = new Set<MessagePort>();
+export default function getAllTransfer(data: unknown): Transferable[] {
+  const transferSet = new Set<Transferable>();
 
   workthru(data, value => {
-    isTransferable(value) && transferSet.add(value);
+    if (isTransferable(value)) {
+      transferSet.add(value as Transferable);
+    }
 
     return value;
   });
 
-  return Array.from(transferSet.values());
+  return Array.from(transferSet);
 }

--- a/packages/message-port-rpc/src/getAllTransfer.ts
+++ b/packages/message-port-rpc/src/getAllTransfer.ts
@@ -1,0 +1,14 @@
+import { workthru } from 'workthru';
+import isTransferable from './isTransferable.ts';
+
+export default function getAllTransfer(data: unknown): MessagePort[] {
+  const transferSet = new Set<MessagePort>();
+
+  workthru(data, value => {
+    isTransferable(value) && transferSet.add(value);
+
+    return value;
+  });
+
+  return Array.from(transferSet.values());
+}

--- a/packages/message-port-rpc/src/isTransferable.ts
+++ b/packages/message-port-rpc/src/isTransferable.ts
@@ -1,0 +1,94 @@
+function isArrayBuffer(value: unknown): value is ArrayBuffer {
+  return !!('ArrayBuffer' in globalThis) && value instanceof ArrayBuffer;
+}
+
+function isAudioData(value: unknown): value is AudioData {
+  return !!('AudioData' in globalThis) && value instanceof AudioData;
+}
+
+function isImageBitmap(value: unknown): value is ImageBitmap {
+  return !!('ImageBitmap' in globalThis) && value instanceof ImageBitmap;
+}
+
+function isMediaSourceHandle(value: unknown): value is MediaSourceHandle {
+  return !!('MediaSourceHandle' in globalThis) && value instanceof MediaSourceHandle;
+}
+
+function isMediaStreamTrack(value: unknown): value is MediaStreamTrack {
+  return !!('MediaStreamTrack' in globalThis) && value instanceof MediaStreamTrack;
+}
+
+function isMessagePort(value: unknown): value is MessagePort {
+  return !!('MessagePort' in globalThis) && value instanceof MessagePort;
+}
+
+function isMIDIAccess(value: unknown): value is MIDIAccess {
+  return !!('MIDIAccess' in globalThis) && value instanceof MIDIAccess;
+}
+
+function isOffscreenCanvas(value: unknown): value is OffscreenCanvas {
+  return !!('OffscreenCanvas' in globalThis) && value instanceof OffscreenCanvas;
+}
+
+function isReadableStream(value: unknown): value is ReadableStream {
+  return !!('ReadableStream' in globalThis) && value instanceof ReadableStream;
+}
+
+function isRTCDataChannel(value: unknown): value is RTCDataChannel {
+  return !!('RTCDataChannel' in globalThis) && value instanceof RTCDataChannel;
+}
+
+function isTransformStream(value: unknown): value is TransformStream {
+  return !!('TransformStream' in globalThis) && value instanceof TransformStream;
+}
+
+function isVideoFrame(value: unknown): value is VideoFrame {
+  return !!('VideoFrame' in globalThis) && value instanceof VideoFrame;
+}
+
+function isWebTransportReceiveStream(value: unknown): boolean {
+  return (
+    !!(
+      (
+        'WebTransportReceiveStream' in globalThis &&
+        typeof (globalThis as any)['WebTransportReceiveStream'] === 'function'
+      )
+      // @ts-ignore
+    ) && value instanceof globalThis.WebTransportReceiveStream
+  );
+}
+
+function isWebTransportSendStream(value: unknown): boolean {
+  return (
+    !!(
+      ('WebTransportSendStream' in globalThis && typeof (globalThis as any)['WebTransportSendStream'] === 'function')
+      // @ts-ignore
+    ) && value instanceof globalThis.WebTransportSendStream
+  );
+}
+
+function isWritableStream(value: unknown): value is WritableStream {
+  return !!('WritableStream' in globalThis) && value instanceof WritableStream;
+}
+
+function isTransferable(value: unknown): boolean {
+  return (
+    isArrayBuffer(value) ||
+    isAudioData(value) ||
+    isImageBitmap(value) ||
+    isMediaSourceHandle(value) ||
+    isMediaStreamTrack(value) ||
+    isMessagePort(value) ||
+    isMIDIAccess(value) ||
+    isOffscreenCanvas(value) ||
+    isReadableStream(value) ||
+    isRTCDataChannel(value) ||
+    isTransformStream(value) ||
+    isVideoFrame(value) ||
+    isWebTransportReceiveStream(value) ||
+    isWebTransportSendStream(value) ||
+    isWritableStream(value)
+  );
+}
+
+export default isTransferable;

--- a/packages/message-port-rpc/src/isTransferable.ts
+++ b/packages/message-port-rpc/src/isTransferable.ts
@@ -51,9 +51,10 @@ function isWebTransportReceiveStream(value: unknown): boolean {
     !!(
       (
         'WebTransportReceiveStream' in globalThis &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         typeof (globalThis as any)['WebTransportReceiveStream'] === 'function'
       )
-      // @ts-ignore
+      // @ts-expect-error WebTransportReceiveStream is not in TypeScript yet
     ) && value instanceof globalThis.WebTransportReceiveStream
   );
 }
@@ -61,8 +62,9 @@ function isWebTransportReceiveStream(value: unknown): boolean {
 function isWebTransportSendStream(value: unknown): boolean {
   return (
     !!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ('WebTransportSendStream' in globalThis && typeof (globalThis as any)['WebTransportSendStream'] === 'function')
-      // @ts-ignore
+      // @ts-expect-error WebTransportSendStream is not in TypeScript yet
     ) && value instanceof globalThis.WebTransportSendStream
   );
 }

--- a/packages/message-port-rpc/src/messagePortRPC.ts
+++ b/packages/message-port-rpc/src/messagePortRPC.ts
@@ -1,5 +1,6 @@
 // Naming is from https://www.w3.org/History/1992/nfs_dxcern_mirror/rpc/doc/Introduction/HowItWorks.html.
 
+import getAllTransfer from './getAllTransfer.ts';
 import { type ReturnValueOfPromise } from './private/types/ReturnValueOfPromise.ts';
 
 const ABORT = 'ABORT';
@@ -16,7 +17,6 @@ type RPCResolveMessage<T extends Subroutine> = [typeof RESOLVE, ReturnValueOfPro
 
 type CallInit = {
   signal?: AbortSignal | undefined;
-  transfer?: readonly Transferable[] | undefined;
 };
 
 // Regardless whether T returns Promise or not, the client stub must return Promise.
@@ -27,7 +27,6 @@ type ClientStubWithExtra<T extends Subroutine> = ClientStub<T> & {
    * Creates a new stub with options.
    *
    * @param {AbortSignal} init.signal - Abort signal to abort the call to the stub.
-   * @param {Transferable[]} init.transfer - Transfer ownership of objects specified in `args`.
    */
   withOptions: (init: CallInit) => ClientStub<T>;
 };
@@ -45,9 +44,9 @@ type ServerStub<T extends Subroutine> = (this: { signal: AbortSignal }, ...args:
  * This function supports bidirectional RPC when both sides are passing the `fn` argument.
  *
  * When calling the returned function stub, the arguments and return value are transferred over `MessagePort`.
- * Thus, they will be cloned by the underlying structured clone algorithm.
+ * Thus, they should be cloned by the underlying structured clone algorithm provided by the `MessagePort` implementation.
  *
- * The returned stub has a variant `withOptions` for passing transferables and abort signal.
+ * The returned stub has a variant `withOptions` for passing abort signal.
  *
  * @param {MessagePort} port - The `MessagePort` object to send the calls. The underlying `MessageChannel` must be exclusively used by this function only.
  * @param {Function} fn - The function to invoke. If not set, this RPC cannot be invoked by the other side of `MessagePort`.
@@ -100,10 +99,9 @@ export default function messagePortRPC<C extends Subroutine, S extends Subroutin
           try {
             returnPort.onmessage = ({ data }) => Array.isArray(data) && data[0] === ABORT && abortController.abort();
 
-            returnPort.postMessage([
-              RESOLVE,
-              await fn.call({ signal: abortController.signal }, ...(data.slice(1) as Parameters<S>))
-            ]);
+            const result = await fn.call({ signal: abortController.signal }, ...(data.slice(1) as Parameters<S>));
+
+            returnPort.postMessage([RESOLVE, result], getAllTransfer(result));
           } catch (error) {
             returnPort.postMessage([REJECT, error]);
           } finally {
@@ -150,7 +148,9 @@ export default function messagePortRPC<C extends Subroutine, S extends Subroutin
           reject(new Error('Aborted.'));
         });
 
-        port.postMessage([CALL, ...args] satisfies RPCCallMessage<C>, [port2, ...(init.transfer || [])]);
+        const transfer = getAllTransfer(args);
+
+        port.postMessage([CALL, ...args] satisfies RPCCallMessage<C>, [port2, ...transfer]);
       });
     };
 

--- a/packages/message-port-rpc/src/messagePortRPC.ts
+++ b/packages/message-port-rpc/src/messagePortRPC.ts
@@ -43,8 +43,9 @@ type ServerStub<T extends Subroutine> = (this: { signal: AbortSignal }, ...args:
  *
  * This function supports bidirectional RPC when both sides are passing the `fn` argument.
  *
- * When calling the returned function stub, the arguments and return value are transferred over `MessagePort`.
- * Thus, they should be cloned by the underlying structured clone algorithm provided by the `MessagePort` implementation.
+ * When calling the returned function stub, the arguments and return value are sent over `MessagePort`.
+ * They would be sent by the underlying structured clone algorithm provided by the `MessagePort` implementation.
+ * Transferable are auto-populated and will be passed to `MessagePort.postMessage` call.
  *
  * The returned stub has a variant `withOptions` for passing abort signal.
  *

--- a/packages/message-port-rpc/src/tests/autoTransfer.client.test.ts
+++ b/packages/message-port-rpc/src/tests/autoTransfer.client.test.ts
@@ -1,0 +1,51 @@
+import NodeTest from 'node:test';
+import messagePortRPC from '../messagePortRPC.ts';
+import { scenario } from '@testduet/given-when-then';
+import { relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import expect from 'expect';
+import { waitFor } from '@testduet/wait-for';
+
+scenario(
+  relative(process.cwd(), fileURLToPath(import.meta.url)),
+  bdd => {
+    bdd
+      .given(
+        'server stub which send MessagePort',
+        () => {
+          const { port1, port2 } = new MessageChannel();
+          const { port1: innerPort1, port2: innerPort2 } = new MessageChannel();
+          const messages: unknown[] = [];
+
+          messagePortRPC(port1, () => innerPort1);
+
+          innerPort2.addEventListener('message', ({ data }) => messages.push(data));
+          innerPort2.start();
+
+          const teardown = () => {
+            port1.close();
+            port2.close();
+            innerPort1.close();
+            innerPort2.close();
+          };
+
+          const client = messagePortRPC<() => MessagePort>(port2);
+
+          return { client, messages, teardown };
+        },
+        ({ teardown }) => teardown()
+      )
+      .when('client stub is called', async ({ client }) => {
+        return await client();
+      })
+      .then('should return a MessagePort', (_, messagePort) => {
+        expect(messagePort).toEqual(expect.any(MessagePort));
+      })
+      .and('calling the inner MessagePort should work', async ({ messages }, messagePort) => {
+        messagePort.postMessage('Hello, World!');
+
+        await waitFor(() => expect(messages).toEqual(['Hello, World!']));
+      });
+  },
+  NodeTest
+);

--- a/packages/message-port-rpc/src/tests/autoTransfer.server.test.ts
+++ b/packages/message-port-rpc/src/tests/autoTransfer.server.test.ts
@@ -1,0 +1,48 @@
+import NodeTest from 'node:test';
+import messagePortRPC from '../messagePortRPC.ts';
+import { scenario } from '@testduet/given-when-then';
+import { relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import expect from 'expect';
+import { waitFor } from '@testduet/wait-for';
+
+scenario(
+  relative(process.cwd(), fileURLToPath(import.meta.url)),
+  bdd => {
+    bdd
+      .given(
+        'client stub which send MessagePort',
+        () => {
+          const { port1, port2 } = new MessageChannel();
+          const { port1: innerPort1, port2: innerPort2 } = new MessageChannel();
+          const messages: unknown[] = [];
+
+          messagePortRPC<(messagePort: MessagePort) => void>(port1, innerPort => {
+            innerPort.addEventListener('message', ({ data }) => messages.push(data));
+            innerPort.start();
+          });
+
+          innerPort2.postMessage('Hello, World!');
+
+          const teardown = () => {
+            port1.close();
+            port2.close();
+            innerPort1.close();
+            innerPort2.close();
+          };
+
+          const client = messagePortRPC<(messagePort: MessagePort) => void>(port2);
+
+          return { client, innerPort1, messages, teardown };
+        },
+        ({ teardown }) => teardown()
+      )
+      .when('client stub is called', async ({ client, innerPort1 }) => {
+        return await client(innerPort1);
+      })
+      .then('should send the MessagePort and calling the inner MessagePort should work', async ({ messages }) => {
+        await waitFor(() => expect(messages).toEqual(['Hello, World!']));
+      });
+  },
+  NodeTest
+);

--- a/packages/message-port-rpc/src/tests/withTransferables.test.ts
+++ b/packages/message-port-rpc/src/tests/withTransferables.test.ts
@@ -32,7 +32,7 @@ describe('send transferables', () => {
 
       const arrayBuffer = new Int8Array([1, 2, 3]).buffer;
 
-      rpc.withOptions({ transfer: [arrayBuffer, port1] })(arrayBuffer, port1);
+      rpc(arrayBuffer, port1);
 
       await waitFor(() => expect(fn.mock.callCount()).toBe(1));
     });

--- a/packages/pages/src/iframe/useReducerSource.ts
+++ b/packages/pages/src/iframe/useReducerSource.ts
@@ -37,8 +37,7 @@ export default function useReducerSource<R extends Reducer<any, any>, I>(
 
     messagePortRPC<(port: MessagePort) => void>(port)
       .withOptions({
-        signal: abortController.signal,
-        transfer: [port1]
+        signal: abortController.signal
       })(port1)
       .catch(() => {
         // Ignore intentional rejection.


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Transferable objects in call arguments and return values are automatically added to `TransferList`, by [@compulim](https://github.com/compulim) in PR [#65](https://github.com/compulim/message-port-rpc/pull/65)

### Removed

- 💥 `transfer` in call `Options` is removed in favor of the auto-transfer feature, by [@compulim](https://github.com/compulim) in PR [#65](https://github.com/compulim/message-port-rpc/pull/65)

## Specific changes

> Please list each individual specific change in this pull request.

- Added `workflow` to traverse the payload and extract transferable object
   - Transferable is based on https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects
- Removed `Options.transfer` as it is obsoleted by this auto transfer feature