### PR TITLE
Use `Awaited` instead of custom types

### DIFF
--- a/.eslintrc.production.yml
+++ b/.eslintrc.production.yml
@@ -18,9 +18,7 @@ rules:
   import/no-self-import: error
   import/no-useless-path-segments: error
   import/no-webpack-loader-syntax: error
-  import/consistent-type-specifier-style:
-    - error
-    - prefer-inline
+  import/consistent-type-specifier-style: off
   import/exports-last: error
   import/extensions:
     - error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `ClientStub` should use built-in [`Awaited<T>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype) to improve support of unwrapping `Promise` return value, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/message-port-rpc/pull/XXX)
+- `ClientStub` should use built-in [`Awaited<T>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype) to improve support of unwrapping `Promise` return value, by [@compulim](https://github.com/compulim) in PR [#69](https://github.com/compulim/message-port-rpc/pull/69)
 
 ## [3.0.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ClientStub` should use built-in [`Awaited<T>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype) to improve support of unwrapping `Promise` return value, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/message-port-rpc/pull/XXX)
+
 ## [3.0.0] - 2026-06-11
 
 ### Added
@@ -49,11 +53,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `forGenerator` should close associated `MessagePort` after `{ done: true }`, by [@compulim](https://github.com/compulim) in PR [#58](https://github.com/compulim/message-port-rpc/pull/58)
-   - After sending/receiving `{ done: true }`, all `MessagePort` will be closed on both server and client side, client behavior will be emulated locally
-   - To close associated `MessagePort` prematurely, use `await [Symbol.asyncDispose]()`
+  - After sending/receiving `{ done: true }`, all `MessagePort` will be closed on both server and client side, client behavior will be emulated locally
+  - To close associated `MessagePort` prematurely, use `await [Symbol.asyncDispose]()`
 - Fixed `forGenerator` client should warn when connected to a non-server, by [@compulim](https://github.com/compulim) in PR [#58](https://github.com/compulim/message-port-rpc/pull/58)
 - Fixed `forGenerator` that all post-done behaviors should match native generator, by [@compulim](https://github.com/compulim) in PR [#58](https://github.com/compulim/message-port-rpc/pull/58)
-   - After receiving `{ done: true }`, `next()` should return `undefined`, `return()` should return the passing value, and `throw()` should throw
+  - After receiving `{ done: true }`, `next()` should return `undefined`, `return()` should return the passing value, and `throw()` should throw
 
 ## [2.0.0] - 2025-12-22
 
@@ -67,37 +71,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 💢 Moved build tools from Babel to tsup/esbuild
 - Integration tests ported to mocha for better test conclusiveness, in PR [#40](https://github.com/compulim/message-port-rpc/pull/40)
 - Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#29](https://github.com/compulim/message-port-rpc/pull/29), [#30](https://github.com/compulim/message-port-rpc/pull/30), [#38](https://github.com/compulim/message-port-rpc/pull/38), and [#42](https://github.com/compulim/message-port-rpc/pull/42)
-   - Production dependencies
-      - [`@babel/runtime-corejs3@7.24.1`](https://npmjs.com/package/@babel/runtime-corejs3)
-   - Development dependencies
-      - [`@babel/cli@7.24.1`](https://npmjs.com/package/@babel/cli)
-      - [`@babel/core@7.24.3`](https://npmjs.com/package/@babel/core)
-      - [`@babel/plugin-transform-runtime@7.24.3`](https://npmjs.com/package/@babel/plugin-transform-runtime)
-      - [`@babel/preset-env@7.24.7`](https://npmjs.com/package/@babel/preset-env/v/7.24.7)
-      - [`@babel/preset-react@7.24.6`](https://npmjs.com/package/@babel/preset-react/v/7.24.6)
-      - [`@babel/preset-typescript@7.24.7`](https://npmjs.com/package/@babel/preset-typescript/v/7.24.7)
-      - [`@tsconfig/recommended@1.0.6`](https://npmjs.com/package/@tsconfig/recommended/v/1.0.6)
-      - [`@tsconfig/strictest@2.0.5`](https://npmjs.com/package/@tsconfig/strictest/v/2.0.5)
-      - [`@types/jest@29.5.12`](https://npmjs.com/package/@types/jest)
-      - [`@types/node@20.14.9`](https://npmjs.com/package/@types/node/v/20.14.9)
-      - [`@types/react-dom@18.3.0`](https://npmjs.com/package/@types/react-dom/v/18.3.0)
-      - [`@types/react@18.3.3`](https://npmjs.com/package/@types/react/v/18.3.3)
-      - [`@typescript-eslint/eslint-plugin@7.4.0`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
-      - [`@typescript-eslint/parser@7.4.0`](https://npmjs.com/package/@typescript-eslint/parser)
-      - [`esbuild@0.21.4`](https://npmjs.com/package/esbuild/v/0.21.4)
-      - [`esbuild@0.21.5`](https://npmjs.com/package/esbuild/v/0.21.5)
-      - [`eslint-plugin-prettier@5.1.3`](https://npmjs.com/package/eslint-plugin-prettier)
-      - [`eslint-plugin-react@7.34.1`](https://npmjs.com/package/eslint-plugin-react)
-      - [`eslint@8.57.0`](https://npmjs.com/package/eslint)
-      - [`jest@29.7.0`](https://npmjs.com/package/jest)
-      - [`prettier@3.3.2`](https://npmjs.com/package/prettier/v/3.3.2)
-      - [`react-dom@18.3.1`](https://npmjs.com/package/react-dom/v/18.3.1)
-      - [`react@18.3.1`](https://npmjs.com/package/react/v/18.3.1)
-      - [`tsup@8.1.0`](https://npmjs.com/package/tsup/v/8.1.0)
-      - [`typescript@5.5.2`](https://npmjs.com/package/typescript/v/5.5.2)
-      - [`use-ref-from@0.1.0`](https://npmjs.com/package/use-ref-from/v/0.1.0)
+  - Production dependencies
+    - [`@babel/runtime-corejs3@7.24.1`](https://npmjs.com/package/@babel/runtime-corejs3)
+  - Development dependencies
+    - [`@babel/cli@7.24.1`](https://npmjs.com/package/@babel/cli)
+    - [`@babel/core@7.24.3`](https://npmjs.com/package/@babel/core)
+    - [`@babel/plugin-transform-runtime@7.24.3`](https://npmjs.com/package/@babel/plugin-transform-runtime)
+    - [`@babel/preset-env@7.24.7`](https://npmjs.com/package/@babel/preset-env/v/7.24.7)
+    - [`@babel/preset-react@7.24.6`](https://npmjs.com/package/@babel/preset-react/v/7.24.6)
+    - [`@babel/preset-typescript@7.24.7`](https://npmjs.com/package/@babel/preset-typescript/v/7.24.7)
+    - [`@tsconfig/recommended@1.0.6`](https://npmjs.com/package/@tsconfig/recommended/v/1.0.6)
+    - [`@tsconfig/strictest@2.0.5`](https://npmjs.com/package/@tsconfig/strictest/v/2.0.5)
+    - [`@types/jest@29.5.12`](https://npmjs.com/package/@types/jest)
+    - [`@types/node@20.14.9`](https://npmjs.com/package/@types/node/v/20.14.9)
+    - [`@types/react-dom@18.3.0`](https://npmjs.com/package/@types/react-dom/v/18.3.0)
+    - [`@types/react@18.3.3`](https://npmjs.com/package/@types/react/v/18.3.3)
+    - [`@typescript-eslint/eslint-plugin@7.4.0`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
+    - [`@typescript-eslint/parser@7.4.0`](https://npmjs.com/package/@typescript-eslint/parser)
+    - [`esbuild@0.21.4`](https://npmjs.com/package/esbuild/v/0.21.4)
+    - [`esbuild@0.21.5`](https://npmjs.com/package/esbuild/v/0.21.5)
+    - [`eslint-plugin-prettier@5.1.3`](https://npmjs.com/package/eslint-plugin-prettier)
+    - [`eslint-plugin-react@7.34.1`](https://npmjs.com/package/eslint-plugin-react)
+    - [`eslint@8.57.0`](https://npmjs.com/package/eslint)
+    - [`jest@29.7.0`](https://npmjs.com/package/jest)
+    - [`prettier@3.3.2`](https://npmjs.com/package/prettier/v/3.3.2)
+    - [`react-dom@18.3.1`](https://npmjs.com/package/react-dom/v/18.3.1)
+    - [`react@18.3.1`](https://npmjs.com/package/react/v/18.3.1)
+    - [`tsup@8.1.0`](https://npmjs.com/package/tsup/v/8.1.0)
+    - [`typescript@5.5.2`](https://npmjs.com/package/typescript/v/5.5.2)
+    - [`use-ref-from@0.1.0`](https://npmjs.com/package/use-ref-from/v/0.1.0)
 - Updated pull request validation to test against various React versions, in PR [#33](https://github.com/compulim/message-port-rpc/pull/33)
-   - Moved from JSX Runtime to JSX Classic to support testing against React 16
+  - Moved from JSX Runtime to JSX Classic to support testing against React 16
 - Added [ESLint import/export syntax](https://npmjs.com/package/eslint-plugin-import), in PR [#43](https://github.com/compulim/message-port-rpc/pull/43)
 - Added [`publint`](https://npmjs.com/package/publint), in PR [#43](https://github.com/compulim/message-port-rpc/pull/43)
 - Bumped dependencies, in PR [#45](https://github.com/compulim/message-port-rpc/pull/45)
@@ -151,7 +155,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - 💢 Removed named exports, please import the defaults instead
-   - Use `import { messagePortRPC } from 'message-port-rpc'` instead
+  - Use `import { messagePortRPC } from 'message-port-rpc'` instead
 
 ## [1.0.1] - 2023-10-09
 
@@ -159,26 +163,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updates `tsconfig.json` to extend from [`@tsconfig/strictest`](https://npmjs.com/package/@tsconfig/strictest), by [@compulim](https://github.com/compulim), in PR [#8](https://github.com/compulim/message-port-rpc/pull/8) and PR [#9](https://github.com/compulim/message-port-rpc/pull/9)
 - Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#17](https://github.com/compulim/message-port-rpc/pull/17), and PR [#26](https://github.com/compulim/message-port-rpc/pull/26)
-   - Production dependencies
-      - [`@babel/runtime-corejs3@7.23.1`](https://npmjs.com/package/@babel/runtime-corejs3)
-   - Development dependencies
-      - [`@babel/cli@7.23.0`](https://npmjs.com/package/@babel/cli)
-      - [`@babel/core@7.23.0`](https://npmjs.com/package/@babel/core)
-      - [`@babel/plugin-transform-runtime@7.22.15`](https://npmjs.com/package/@babel/plugin-transform-runtime)
-      - [`@babel/preset-env@7.22.20`](https://npmjs.com/package/@babel/preset-env)
-      - [`@babel/preset-typescript@7.23.0`](https://npmjs.com/package/@babel/preset-typescript)
-      - [`@jest/globals@29.7.0`](https://npmjs.com/package/@jest/globals)
-      - [`@tsconfig/recommended@1.0.3`](https://npmjs.com/package/@tsconfig/recommended)
-      - [`@types/jest@29.5.5`](https://npmjs.com/package/@types/jest)
-      - [`@types/node@20.8.3`](https://npmjs.com/package/@types/node)
-      - [`@typescript-eslint/eslint-plugin@6.7.4`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
-      - [`@typescript-eslint/parser@6.7.4`](https://npmjs.com/package/@typescript-eslint/parser)
-      - [`esbuild@0.19.4`](https://npmjs.com/package/esbuild)
-      - [`eslint-plugin-react@7.33.2`](https://npmjs.com/package/eslint-plugin-react)
-      - [`eslint@8.51.0`](https://npmjs.com/package/eslint)
-      - [`jest@29.7.0`](https://npmjs.com/package/jest)
-      - [`prettier@3.0.3`](https://npmjs.com/package/prettier)
-      - [`typescript@5.2.2`](https://npmjs.com/package/typescript)
+  - Production dependencies
+    - [`@babel/runtime-corejs3@7.23.1`](https://npmjs.com/package/@babel/runtime-corejs3)
+  - Development dependencies
+    - [`@babel/cli@7.23.0`](https://npmjs.com/package/@babel/cli)
+    - [`@babel/core@7.23.0`](https://npmjs.com/package/@babel/core)
+    - [`@babel/plugin-transform-runtime@7.22.15`](https://npmjs.com/package/@babel/plugin-transform-runtime)
+    - [`@babel/preset-env@7.22.20`](https://npmjs.com/package/@babel/preset-env)
+    - [`@babel/preset-typescript@7.23.0`](https://npmjs.com/package/@babel/preset-typescript)
+    - [`@jest/globals@29.7.0`](https://npmjs.com/package/@jest/globals)
+    - [`@tsconfig/recommended@1.0.3`](https://npmjs.com/package/@tsconfig/recommended)
+    - [`@types/jest@29.5.5`](https://npmjs.com/package/@types/jest)
+    - [`@types/node@20.8.3`](https://npmjs.com/package/@types/node)
+    - [`@typescript-eslint/eslint-plugin@6.7.4`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
+    - [`@typescript-eslint/parser@6.7.4`](https://npmjs.com/package/@typescript-eslint/parser)
+    - [`esbuild@0.19.4`](https://npmjs.com/package/esbuild)
+    - [`eslint-plugin-react@7.33.2`](https://npmjs.com/package/eslint-plugin-react)
+    - [`eslint@8.51.0`](https://npmjs.com/package/eslint)
+    - [`jest@29.7.0`](https://npmjs.com/package/jest)
+    - [`prettier@3.0.3`](https://npmjs.com/package/prettier)
+    - [`typescript@5.2.2`](https://npmjs.com/package/typescript)
 
 ### Fixed
 

--- a/packages/message-port-rpc/src/index.ts
+++ b/packages/message-port-rpc/src/index.ts
@@ -1,4 +1,3 @@
-import forGenerator from './forGenerator.ts';
-import messagePortRPC from './messagePortRPC.ts';
-
-export { forGenerator, messagePortRPC };
+export { default as forGenerator } from './forGenerator.ts';
+export { default as messagePortRPC } from './messagePortRPC.ts';
+export type { CallInit, ClientStub, ServerStub, Subroutine } from './types.ts';

--- a/packages/message-port-rpc/src/messagePortRPC.ts
+++ b/packages/message-port-rpc/src/messagePortRPC.ts
@@ -1,37 +1,17 @@
 // Naming is from https://www.w3.org/History/1992/nfs_dxcern_mirror/rpc/doc/Introduction/HowItWorks.html.
 
 import getAllTransfer from './getAllTransfer.ts';
-import { type ReturnValueOfPromise } from './private/types/ReturnValueOfPromise.ts';
+import type { CallInit, ClientStub, ServerStub, Subroutine } from './types.ts';
 
 const ABORT = 'ABORT';
 const CALL = 'CALL';
 const REJECT = 'REJECT';
 const RESOLVE = 'RESOLVE';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Subroutine = (...args: any[]) => Promise<unknown> | unknown;
 type RPCCallMessage<T extends Subroutine> = [typeof CALL, ...Parameters<T>];
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RPCRejectMessage = [typeof REJECT, any];
-type RPCResolveMessage<T extends Subroutine> = [typeof RESOLVE, ReturnValueOfPromise<ReturnType<T>>];
-
-type CallInit = {
-  signal?: AbortSignal | undefined;
-};
-
-// Regardless whether T returns Promise or not, the client stub must return Promise.
-type ClientStub<T extends Subroutine> = (...args: Parameters<T>) => Promise<ReturnValueOfPromise<ReturnType<T>>>;
-
-type ClientStubWithExtra<T extends Subroutine> = ClientStub<T> & {
-  /**
-   * Creates a new stub with options.
-   *
-   * @param {AbortSignal} init.signal - Abort signal to abort the call to the stub.
-   */
-  withOptions: (init: CallInit) => ClientStub<T>;
-};
-
-type ServerStub<T extends Subroutine> = (this: { signal: AbortSignal }, ...args: Parameters<T>) => ReturnType<T>;
+type RPCResolveMessage<T extends Subroutine> = [typeof RESOLVE, Awaited<ReturnType<T>>];
 
 /**
  * Binds a function to a `MessagePort` in RPC fashion and/or create a RPC function stub connected to a `MessagePort`.
@@ -54,23 +34,23 @@ type ServerStub<T extends Subroutine> = (this: { signal: AbortSignal }, ...args:
  *
  * @returns An asynchronous function, when called, will invoke the function on the other side of `MessagePort`.
  */
-export default function messagePortRPC<C extends Subroutine>(port: MessagePort): ClientStubWithExtra<C>;
+function messagePortRPC<C extends Subroutine>(port: MessagePort): ClientStub<C>;
 
-export default function messagePortRPC<C extends Subroutine, S extends Subroutine = C>(
+function messagePortRPC<C extends Subroutine, S extends Subroutine = C>(
   port: MessagePort,
   fn: ServerStub<S>
-): ClientStubWithExtra<C>;
+): ClientStub<C>;
 
-export default function messagePortRPC<C extends Subroutine, S extends Subroutine = C>(
+function messagePortRPC<C extends Subroutine, S extends Subroutine = C>(
   port: MessagePort,
   fn: ServerStub<S>,
   options: { signal: AbortSignal }
-): ClientStubWithExtra<C>;
+): ClientStub<C>;
 
-export default function messagePortRPC<C extends Subroutine, S extends Subroutine = C>(
+function messagePortRPC<C extends Subroutine, S extends Subroutine = C>(
   port: MessagePort,
   fn?: ServerStub<S>
-): ClientStubWithExtra<C> {
+): ClientStub<C> {
   // We cannot neuter the input port because it would cause memory leak:
   // - We can neuter a port by passing it through Structured Clone Algorithm so the input port will become non-functional
   // - After a port is neutered, closing the neutered port will not close the cloned port
@@ -78,7 +58,7 @@ export default function messagePortRPC<C extends Subroutine, S extends Subroutin
   // - This defeated our philosophy: whoever pass a resources to a function, should own the resources unless it is intentional and no other workarounds
 
   type ClientSubroutineParameters = Parameters<C>;
-  type ClientSubroutineReturnValue = ReturnValueOfPromise<ReturnType<C>>;
+  type ClientSubroutineReturnValue = Awaited<ReturnType<C>>;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleMessage = (event: MessageEvent<RPCCallMessage<S>>): void => {
@@ -155,9 +135,11 @@ export default function messagePortRPC<C extends Subroutine, S extends Subroutin
       });
     };
 
-  const stub = createWithOptions({}) as ClientStubWithExtra<C>;
+  const stub = createWithOptions({}) as ClientStub<C>;
 
   stub.withOptions = createWithOptions;
 
   return stub;
 }
+
+export default messagePortRPC;

--- a/packages/message-port-rpc/src/private/types/ReturnValueOfPromise.ts
+++ b/packages/message-port-rpc/src/private/types/ReturnValueOfPromise.ts
@@ -1,1 +1,0 @@
-export type ReturnValueOfPromise<T> = T extends Promise<infer R> ? R : T;

--- a/packages/message-port-rpc/src/types.ts
+++ b/packages/message-port-rpc/src/types.ts
@@ -1,0 +1,22 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Subroutine = (...args: any[]) => Promise<unknown> | unknown;
+
+type CallInit = {
+  signal?: AbortSignal | undefined;
+};
+
+// Regardless whether T returns Promise or not, the client stub must return Promise.
+type ClientStub_<T extends Subroutine> = (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>>;
+
+type ClientStub<T extends Subroutine> = ClientStub_<T> & {
+  /**
+   * Creates a new stub with options.
+   *
+   * @param {AbortSignal} init.signal - Abort signal to abort the call to the stub.
+   */
+  withOptions: (init: CallInit) => ClientStub_<T>;
+};
+
+type ServerStub<T extends Subroutine> = (this: { signal: AbortSignal }, ...args: Parameters<T>) => ReturnType<T>;
+
+export type { CallInit, ClientStub_, ClientStub, ServerStub, Subroutine };


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- `ClientStub` should use built-in [`Awaited<T>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype) to improve support of unwrapping `Promise` return value, by [@compulim](https://github.com/compulim) in PR [#69](https://github.com/compulim/message-port-rpc/pull/69)

## Specific changes

> Please list each individual specific change in this pull request.

- Removed `ReturnValueOfPromise<T>` in favor of built-in `Awaited<T>`
- Exported `ClientStub`, `ServerStub`, `Subroutine` and `CallInit` for better type portability and reusability